### PR TITLE
Use 7z instead of powershell native compression

### DIFF
--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -111,7 +111,7 @@ function Publish-Portable ($outputLocation, $version) {
     
     & $outputLocation\Flow-Launcher-v$v.exe --silent | Out-Null
     mkdir "$env:LocalAppData\FlowLauncher\app-$version\UserData"
-    Compress-Archive -Path $env:LocalAppData\FlowLauncher -DestinationPath $outputLocation\Flow-Launcher-Portable.zip
+    7z a $outputLocation\Flow-Launcher-Portable.zip $env:LocalAppData\FlowLauncher
 }
 
 function Main {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the post-build script to use 7z instead of PowerShell's native compression for creating portable zip archives. This change aims to improve the compression process in the build pipeline.

* **Enhancements**:
    - Replaced the use of PowerShell's native compression with 7z for creating portable zip archives in the post-build script.

<!-- Generated by sourcery-ai[bot]: end summary -->